### PR TITLE
Fix references to 'netbox_toolkit' in documentation to 'netbox_toolki…

### DIFF
--- a/docs/development/code-guide.md
+++ b/docs/development/code-guide.md
@@ -4,21 +4,21 @@ Quick navigation guide for developers working on the NetBox Toolkit Plugin codeb
 
 ## 📁 Key Files & Classes
 
-### Core Models (`netbox_toolkit/models.py`)
+### Core Models (`netbox_toolkit_plugin/models.py`)
 - **`Command`** - Platform-based commands (show/config types)
 - **`CommandLog`** - Execution history with error detection
 
-### Service Layer (`netbox_toolkit/services/`)
+### Service Layer (`netbox_toolkit_plugin/services/`)
 - **`CommandExecutionService`** - Main command execution logic
 - **`DeviceService`** - Device validation and connection info
 - **`RateLimitingService`** - Prevents command flooding
 
-### Connector Framework (`netbox_toolkit/connectors/`)
+### Connector Framework (`netbox_toolkit_plugin/connectors/`)
 - **`BaseDeviceConnector`** - Abstract interface for all connectors
 - **`ScrapliConnector`** - Scrapli-based implementation (primary)
 - **`ConnectorFactory`** - Creates platform-specific connectors
 
-### Views (`netbox_toolkit/views.py`)
+### Views (`netbox_toolkit_plugin/views.py`)
 - **`DeviceToolkitView`** - Custom "Toolkit" tab on device pages
 - **`CommandListView`** - Command management interface
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -12,7 +12,7 @@ The plugin is configured in NetBox's `configuration.py` file using the `PLUGINS_
 ```python
 # In your NetBox configuration.py
 PLUGINS_CONFIG = {
-    'netbox_toolkit': {
+    'netbox_toolkit_plugin': {
         'rate_limiting_enabled': True,      # Enable/disable rate limiting (default: True)
         'device_command_limit': 10,         # Max commands per device per time window (default: 10)
         'time_window_minutes': 5,           # Time window in minutes (default: 5)

--- a/docs/user/debug-logging.md
+++ b/docs/user/debug-logging.md
@@ -7,7 +7,7 @@ Add this configuration to your NetBox `configuration.py` file to enable debug lo
 ```python
 # Plugin configuration
 PLUGINS_CONFIG = {
-    'netbox_toolkit': {
+    'netbox_toolkit_plugin': {
         # Enable debug logging for the toolkit plugin
         'debug_logging': True,
         
@@ -30,7 +30,7 @@ LOGGING = {
     },
     'filters': {  # Control which log messages are processed
         'require_toolkit_debug': {
-            '()': 'netbox_toolkit.utils.logging.RequireToolkitDebug',
+            '()': 'netbox_toolkit_plugin.utils.logging.RequireToolkitDebug',
         },
     },
     'handlers': {  # Define where log messages are sent (console, file, etc.)
@@ -42,7 +42,7 @@ LOGGING = {
         },
     },
     'loggers': {  # Configure which modules send logs and at what level
-        'netbox_toolkit': {
+        'netbox_toolkit_plugin': {
             'handlers': ['toolkit_console'],
             'level': 'DEBUG',
             'propagate': False,  # Don't send to parent loggers
@@ -63,7 +63,7 @@ You can adjust the logging level based on your needs:
 Example for less verbose logging:
 ```python
 'loggers': {
-    'netbox_toolkit': {
+    'netbox_toolkit_plugin': {
         'handlers': ['toolkit_console'],
         'level': 'INFO',  # Less verbose than DEBUG
         'propagate': False,
@@ -84,7 +84,7 @@ Example for less verbose logging:
 To disable plugin debug logging, simply set:
 ```python
 PLUGINS_CONFIG = {
-    'netbox_toolkit': {
+    'netbox_toolkit_plugin': {
         'debug_logging': False,  # Disable debug logging
     }
 }
@@ -96,9 +96,9 @@ Or remove the `debug_logging` setting entirely (default is `False`).
 
 When enabled, you'll see detailed logging like:
 ```
-[TOOLKIT] DEBUG 2025-06-05 10:30:15 netbox_toolkit.connectors.factory - Creating connector for device router-01 with platform cisco_ios
-[TOOLKIT] DEBUG 2025-06-05 10:30:15 netbox_toolkit.connectors.scrapli_connector - Attempting to connect to 192.168.1.1:22
-[TOOLKIT] INFO 2025-06-05 10:30:16 netbox_toolkit.connectors.scrapli_connector - Successfully connected to 192.168.1.1 using IOSXEDriver
-[TOOLKIT] DEBUG 2025-06-05 10:30:16 netbox_toolkit.services.command_service - Executing show command: show version
-[TOOLKIT] DEBUG 2025-06-05 10:30:17 netbox_toolkit.services.command_service - Command completed successfully in 0.8s
+[TOOLKIT] DEBUG 2025-06-05 10:30:15 netbox_toolkit_plugin.connectors.factory - Creating connector for device router-01 with platform cisco_ios
+[TOOLKIT] DEBUG 2025-06-05 10:30:15 netbox_toolkit_plugin.connectors.scrapli_connector - Attempting to connect to 192.168.1.1:22
+[TOOLKIT] INFO 2025-06-05 10:30:16 netbox_toolkit_plugin.connectors.scrapli_connector - Successfully connected to 192.168.1.1 using IOSXEDriver
+[TOOLKIT] DEBUG 2025-06-05 10:30:16 netbox_toolkit_plugin.services.command_service - Executing show command: show version
+[TOOLKIT] DEBUG 2025-06-05 10:30:17 netbox_toolkit_plugin.services.command_service - Command completed successfully in 0.8s
 ```

--- a/docs/user/permission-examples.md
+++ b/docs/user/permission-examples.md
@@ -70,7 +70,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 1: Toolkit - View Commands
 - **Name**: `Toolkit - View Commands`
-- **Object Types**: Select `Command Toolkit | command`
+- **Object Types**: Select `Command Toolkit Plugin | command`
 - **Actions**: Check `view`
 - **Additional Actions**: Leave empty
 - **Groups**: Select `Junior Network Engineers`, `Senior Network Engineers`, `Network Administrators`
@@ -79,7 +79,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 2: Toolkit - Execute Show Commands
 - **Name**: `Toolkit - Execute Show Commands`
-- **Object Types**: Select `Command Toolkit | command`
+- **Object Types**: Select `Command Toolkit Plugin | command`
 - **Actions**: Leave the checkboxes empty
 - **Additional Actions**: Type `execute_show`
 - **Groups**: Select `Junior Network Engineers`, `Senior Network Engineers`, `Network Administrators`
@@ -88,7 +88,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 3: Toolkit - Execute Config Commands
 - **Name**: `Toolkit - Execute Config Commands`
-- **Object Types**: Select `Command Toolkit | command`
+- **Object Types**: Select `Command Toolkit Plugin | command`
 - **Actions**: Leave the checkboxes empty
 - **Additional Actions**: Type `execute_config`
 - **Groups**: Select `Senior Network Engineers`, `Network Administrators` (NOT Junior Engineers)
@@ -97,7 +97,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 4: Toolkit - Manage Commands
 - **Name**: `Toolkit - Manage Commands`
-- **Object Types**: Select `Command Toolkit | command`
+- **Object Types**: Select `Command Toolkit Plugin | command`
 - **Actions**: Check `add`, `change`, `delete`
 - **Additional Actions**: Leave empty
 - **Groups**: Select `Network Administrators` (ONLY Admins)
@@ -106,7 +106,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 5: Toolkit - View Command Logs
 - **Name**: `Toolkit - View Command Logs`
-- **Object Types**: Select `Command Toolkit | command log`
+- **Object Types**: Select `Command Toolkit Plugin | command log`
 - **Actions**: Check `view`
 - **Additional Actions**: Leave empty
 - **Groups**: Select `Junior Network Engineers`, `Senior Network Engineers`, `Network Administrators`
@@ -115,7 +115,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 
 #### Permission 6: Toolkit - Manage Command Logs
 - **Name**: `Toolkit - Manage Command Logs`
-- **Object Types**: Select `Command Toolkit | command log`
+- **Object Types**: Select `Command Toolkit Plugin | command log`
 - **Actions**: Check `add`, `change`, `delete`
 - **Additional Actions**: Leave empty
 - **Groups**: Select `Network Administrators` (ONLY Admins)
@@ -138,7 +138,7 @@ Navigate to **Admin → Users → Permissions** and create the following **reusa
 #### Permission 1: View Show Version Commands Only
 ```json
 Name: "Toolkit - View Show Version Commands Only"
-Object Types: Command Toolkit | command
+Object Types: Command Toolkit Plugin | command
 Actions: ✓ view
 Additional Actions: (leave empty)
 Constraints: {
@@ -151,7 +151,7 @@ Groups: Junior Network Engineers
 #### Permission 2: Execute Show Version Commands Only
 ```json
 Name: "Toolkit - Execute Show Version Commands Only"
-Object Types: Command Toolkit | command
+Object Types: Command Toolkit Plugin | command
 Actions: (leave unchecked)
 Additional Actions: execute_show
 Constraints: {
@@ -172,7 +172,7 @@ Groups: Junior Network Engineers
 #### Permission 1: View Cisco Commands
 ```json
 Name: "Toolkit - View Cisco Commands"
-Object Types: Command Toolkit | command
+Object Types: Command Toolkit Plugin | command
 Actions: ✓ view
 Constraints: {
   "platform__slug__in": ["cisco_ios", "cisco_nxos", "cisco_iosxr"]
@@ -183,7 +183,7 @@ Groups: Network Team
 #### Permission 2: Execute Cisco Show Commands
 ```json
 Name: "Toolkit - Execute Cisco Show Commands"
-Object Types: Command Toolkit | command
+Object Types: Command Toolkit Plugin | command
 Additional Actions: execute_show
 Constraints: {
   "command_type": "show",
@@ -199,7 +199,7 @@ Groups: Network Team
 #### Permission: Safe Monitoring Commands
 ```json
 Name: "Toolkit - Safe Monitoring Commands"
-Object Types: Command Toolkit | command
+Object Types: Command Toolkit Plugin | command
 Actions: ✓ view
 Additional Actions: execute_show
 Constraints: {


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the naming convention from `netbox_toolkit` to `netbox_toolkit_plugin`. The updates span multiple files, including configuration examples, logging settings, and permissions, ensuring consistency across all references to the plugin.
