### PR TITLE
Add permissions to navigation menu items

### DIFF
--- a/netbox_toolkit_plugin/navigation.py
+++ b/netbox_toolkit_plugin/navigation.py
@@ -11,18 +11,21 @@ menu = PluginMenu(
                 PluginMenuItem(
                     link="plugins:netbox_toolkit_plugin:command_list",
                     link_text="Commands",
+                    permissions=["netbox_toolkit_plugin.view_command"],
                     buttons=(
                         PluginMenuButton(
                             "plugins:netbox_toolkit_plugin:command_add",
                             "Add",
                             "mdi mdi-plus-thick",
                             ButtonColorChoices.GRAY,
+                            permissions=["netbox_toolkit_plugin.add_command"],
                         ),
                     ),
                 ),
                 PluginMenuItem(
                     link="plugins:netbox_toolkit_plugin:commandlog_list",
                     link_text="Command Logs",
+                    permissions=["netbox_toolkit_plugin.view_commandlog"],
                 ),
             ),
         ),


### PR DESCRIPTION
Enhance the navigation menu by adding permissions to specific menu items, ensuring that access control is properly enforced.